### PR TITLE
adds cmake support for examples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,23 +30,34 @@ else ()
   )
 endif ()
 
-enable_testing()
 include(FetchContent)
+
+enable_testing()
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-)
-FetchContent_Declare(
-  portaudio
-  URL http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
-  URL_HASH  MD5=ad319249932c6794b551d954b8844402
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG e2239ee6043f73722e7aa812a459f54a28552929
 )
 if (MSVC)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif ()
 FetchContent_MakeAvailable(googletest)
-FetchContent_MakeAvailable(portaudio)
 include(GoogleTest)
+
+FetchContent_Declare(
+  portaudio
+  GIT_REPOSITORY https://github.com/PortAudio/portaudio.git
+  GIT_TAG 147dd722548358763a8b649b3e4b41dfffbcfbb6
+)
+FetchContent_MakeAvailable(portaudio)
+target_compile_options(
+  portaudio
+  PUBLIC -w
+)
+target_compile_options(
+  portaudio_static
+  PUBLIC -w
+)
 
 include_directories(.)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,20 @@ FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
 )
+FetchContent_Declare(
+  portaudio
+  URL http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
+  URL_HASH  MD5=ad319249932c6794b551d954b8844402
+)
 if (MSVC)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif ()
 FetchContent_MakeAvailable(googletest)
+FetchContent_MakeAvailable(portaudio)
 include(GoogleTest)
 
 include_directories(.)
 
 add_subdirectory(barelymusician)
+add_subdirectory(examples)
 add_subdirectory(unity)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(common)
+add_subdirectory(demo)

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -27,11 +27,11 @@ add_library(
 if (MSVC)
   target_link_options(
     input_manager
-    -l user32.lib
+    PUBLIC -l user32.lib
   )
 elseif (APPLE)
   target_link_options(
     input_manager
-    -framework ApplicationServices
+    PUBLIC -framework ApplicationServices
   )
 endif ()

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_library(
+  audio_clock
+  audio_clock.cpp
+  audio_clock.h
+)
+
+add_library(
+  audio_output
+  audio_output.cpp
+  audio_output.h
+)
+target_link_libraries(
+  audio_output
+  portaudio_static
+)
+
+add_library(
+  console_log INTERFACE
+  console_log.h
+)
+
+add_library(
+  input_manager
+  input_manager.cpp
+  input_manager.h
+)
+if (MSVC)
+  target_link_options(
+    input_manager
+    -l user32.lib
+  )
+elseif (APPLE)
+  target_link_options(
+    input_manager
+    -framework ApplicationServices
+  )
+endif ()

--- a/examples/demo/CMakeLists.txt
+++ b/examples/demo/CMakeLists.txt
@@ -11,3 +11,50 @@ target_link_libraries(
   console_log
   input_manager
 )
+
+add_executable(
+  metronome_demo
+  metronome_demo.cpp
+)
+target_link_libraries(
+  metronome_demo
+  barelymusician
+  metronome
+  pitch
+  synth_instrument
+  audio_clock
+  audio_output
+  console_log
+  input_manager
+)
+
+add_executable(
+  sequencer_demo
+  sequencer_demo.cpp
+)
+target_link_libraries(
+  sequencer_demo
+  barelymusician
+  pitch
+  synth_instrument
+  audio_clock
+  audio_output
+  console_log
+  input_manager
+)
+
+add_executable(
+  trigger_demo
+  trigger_demo.cpp
+)
+target_link_libraries(
+  trigger_demo
+  barelymusician
+  pitch
+  synth_instrument
+  audio_clock
+  audio_output
+  console_log
+  input_manager
+)
+

--- a/examples/demo/CMakeLists.txt
+++ b/examples/demo/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(
+  instrument_demo
+  instrument_demo.cpp
+)
+target_link_libraries(
+  instrument_demo
+  barelymusician
+  pitch
+  synth_instrument
+  audio_output
+  console_log
+  input_manager
+)


### PR DESCRIPTION
CMake targets for the executables in `examples/demos` are added except for the ones that use external files (see #116).